### PR TITLE
[FEAT] 친구등록, 친구요청 파베연결 #125

### DIFF
--- a/Zipadoo/Zipadoo.xcodeproj/project.pbxproj
+++ b/Zipadoo/Zipadoo.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		8B973A372AC5930D00C67B5F /* SigninByEmail2View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B973A322AC5930D00C67B5F /* SigninByEmail2View.swift */; };
 		8B973A382AC5930D00C67B5F /* SigninByEmailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B973A332AC5930D00C67B5F /* SigninByEmailView.swift */; };
 		8B973A3A2AC593DE00C67B5F /* KakaoTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B973A392AC593DE00C67B5F /* KakaoTest.swift */; };
+		8BA14B1A2AD44EF800DEB733 /* FriendsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA14B192AD44EF800DEB733 /* FriendsStore.swift */; };
 		8BD44EC62AC13FD900A4694C /* ProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD44EC52AC13FD900A4694C /* ProfileImageView.swift */; };
 		8BD44ECA2AC1401E00A4694C /* UserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD44EC92AC1401E00A4694C /* UserModel.swift */; };
 		8BDF9CCE2ABD1F7D00255857 /* FriendsRegistrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDF9CCD2ABD1F7D00255857 /* FriendsRegistrationView.swift */; };
@@ -110,6 +111,7 @@
 		8B973A322AC5930D00C67B5F /* SigninByEmail2View.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SigninByEmail2View.swift; sourceTree = "<group>"; };
 		8B973A332AC5930D00C67B5F /* SigninByEmailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SigninByEmailView.swift; sourceTree = "<group>"; };
 		8B973A392AC593DE00C67B5F /* KakaoTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KakaoTest.swift; sourceTree = "<group>"; };
+		8BA14B192AD44EF800DEB733 /* FriendsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsStore.swift; sourceTree = "<group>"; };
 		8BD44EC52AC13FD900A4694C /* ProfileImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileImageView.swift; sourceTree = "<group>"; };
 		8BD44EC92AC1401E00A4694C /* UserModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserModel.swift; sourceTree = "<group>"; };
 		8BDF9CCD2ABD1F7D00255857 /* FriendsRegistrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsRegistrationView.swift; sourceTree = "<group>"; };
@@ -226,6 +228,14 @@
 			path = Login;
 			sourceTree = "<group>";
 		};
+		8BA14B182AD44ECE00DEB733 /* Friends */ = {
+			isa = PBXGroup;
+			children = (
+				8BA14B192AD44EF800DEB733 /* FriendsStore.swift */,
+			);
+			path = Friends;
+			sourceTree = "<group>";
+		};
 		8BAAEAC92ABC444800477574 /* Friends */ = {
 			isa = PBXGroup;
 			children = (
@@ -337,6 +347,7 @@
 				FA2474322ACD4D6E00D4C821 /* UserStore.swift */,
 				FA2474402ACD4D6E00D4C821 /* Login */,
 				FA2474332ACD4D6E00D4C821 /* Home */,
+				8BA14B182AD44ECE00DEB733 /* Friends */,
 				FA24743B2ACD4D6E00D4C821 /* MyPage */,
 				FA2474382ACD4D6E00D4C821 /* ProfileImageUploader.swift */,
 				FA2474392ACD4D6E00D4C821 /* ImagePicker.swift */,
@@ -603,6 +614,7 @@
 				FA2474252ACD4BDB00D4C821 /* AddPromiseTitleCell.swift in Sources */,
 				FA2474472ACD4D6E00D4C821 /* MapViewContainer.swift in Sources */,
 				FA2474122ACD4BDB00D4C821 /* SearchbarCell.swift in Sources */,
+				8BA14B1A2AD44EF800DEB733 /* FriendsStore.swift in Sources */,
 				FA24740B2ACD4BDB00D4C821 /* FriendsLocationListView.swift in Sources */,
 				8BEDA03B2ACE45890056046B /* EditPasswordView.swift in Sources */,
 				FA24741A2ACD4BDB00D4C821 /* AddPromiseView.swift in Sources */,

--- a/Zipadoo/Zipadoo/Models/UserModel.swift
+++ b/Zipadoo/Zipadoo/Models/UserModel.swift
@@ -24,7 +24,10 @@ struct User: Codable, Identifiable {
     var crustDepth: Int = 0
     /// 유저의 지각 약속 수
     var tardyCount: Int = 0
-    
+    /// 친구 id 배열
+    var friendsIdArray: [String]
+    /// 친구요청 id배역
+    var friendsIdRequestArray: [String]
     /*
     /// 유저의 약속 수
     let promiseCount: Int?

--- a/Zipadoo/Zipadoo/ViewModels/Friends/FriendsStore.swift
+++ b/Zipadoo/Zipadoo/ViewModels/Friends/FriendsStore.swift
@@ -1,0 +1,285 @@
+//
+//  FriendsStore.swift
+//  Zipadoo
+//
+//  Created by 남현정 on 2023/10/10.
+//
+
+import Firebase
+ import SwiftUI
+
+ /// 친구등록, 친구불러오기
+ final class FriendsStore: ObservableObject {
+     /// 현재 로그인된 사용자의 친구들
+     @Published var friendsFetchArray: [User] = []
+     /// 친구요청한 친구들
+     @Published var requestFetchArray: [User] = []
+     /// 로그인된 사용자
+     var currentUser: User? = AuthStore.shared.currentUser
+
+     var friendsIdArray: [String] = []
+     var friendsIdRequestArray: [String] = []
+
+     @Published var alertMessage: String = ""
+
+     let dbRef = Firestore.firestore().collection("Users")
+
+     /// 사용자의 친구 가져오기
+     @MainActor
+     func fetchFriends() async throws {
+
+         do {
+             // 사용자id로 친구id배열가져오기
+             guard let userId = currentUser?.id else {
+                 return
+             }
+             let user = try await UserStore.fetchUser(userId: userId)
+             friendsIdArray = user?.friendsIdArray ?? []
+             print("fetchFriends : \(friendsIdArray)")
+             // 친구 id로 친구정보 가져오기
+             var tempArray: [User] = []
+
+             for id in friendsIdArray {
+                 let friend: User? = try await UserStore.fetchUser(userId: id)
+                 if let friend {
+                     tempArray.append(friend)
+                 }
+             }
+
+             // 메인 스레드에서 UI 업데이트를 수행합니다.
+             DispatchQueue.main.async {
+                 self.friendsFetchArray = tempArray
+             }
+ //            print(friendsFetchArray)
+  
+         } catch {
+             print("fetch 실패")
+         }
+     }
+
+     /// 친구요청 목록 가져오기
+     @MainActor
+     func fetchFriendsRequest() async throws {
+         do {
+             // 사용자id로 친구id배열가져오기
+             guard let userId = currentUser?.id else {
+                 return
+             }
+             let user = try await UserStore.fetchUser(userId: userId)
+             friendsIdRequestArray = user?.friendsIdRequestArray ?? []
+
+             // 요청목록 가져오기
+             var tempArray: [User] = []
+
+             for id in friendsIdRequestArray {
+
+                 let friend: User? = try await UserStore.fetchUser(userId: id)
+
+                 if let friend {
+                     tempArray.append(friend)
+                 }
+             }
+
+             // 메인 스레드에서 UI 업데이트를 수행합니다.
+             DispatchQueue.main.async {
+                 self.requestFetchArray = tempArray
+             }
+
+         } catch {
+             print("fetchUser실패")
+         }
+
+     }
+
+     /// 친구 닉네임으로 친구id 가져오기
+     @MainActor
+     func findFriend(friendNickname: String, completion: @escaping (Bool) -> Void) async throws {
+
+         let snapshot = dbRef.whereField("nickName", isEqualTo: friendNickname)
+
+         do {
+ //            try await fetchFriends()
+             
+             guard let userId = currentUser?.id else {
+                 return
+             }
+             // 이미 있는 친구 id이면 하지 말기, 내 id면... 하지 말기
+             
+             // 해당 닉네임이 없으면 false반환
+             let querySnapshot = try await snapshot.getDocuments()
+             if querySnapshot.isEmpty {
+                print("해당 닉네임 가진 친구 없음")
+                completion(false) // 중복된 닉네임이 없을 경우 false를 반환
+            } else {
+                // 닉네임이 있으면 조건 따진 후 addRequest 함수 실행
+                guard let document = querySnapshot.documents.first else {
+                    return
+                }
+                let friendId = document.documentID // 친구 아이디
+                // 친구 정보 가져오기
+                let opponent: User? = try await UserStore.fetchUser(userId: friendId)
+                guard let opponent else {
+                    return
+                }
+
+                if friendId == userId {
+                    // 내 아이디인 경우
+                    print("나의 아이디 입력")
+                    alertMessage = "본인에게는 친구요청 할 수 없습니다"
+                    completion(false)
+                } else if friendsIdArray.contains(friendId) {
+                    // 이미 친구인 경우
+                    print("이미 친구")
+                    alertMessage = "이미 친구입니다"
+                    completion(false)
+
+                } else if opponent.friendsIdRequestArray.contains(userId) {
+                    // 이미 요청한 경우
+                    print("이미 요청")
+                    alertMessage = "이미 요청한 친구입니다"
+                   completion(false)
+               } else {
+                   // 조건에 맞는 경우
+                   print("조건에 맞음!")
+                   try await addRequest(friendId: friendId)
+                   completion(true)
+               }
+
+           }
+        } catch {
+            return
+        }
+    }
+
+    /// 친구 추가
+    func addFriend(friendId: String) async throws {
+        do {
+            try await fetchFriends()
+            try await fetchFriendsRequest()
+
+            var updateData = [String: Any]()
+
+            let newIdArray = friendsIdArray + [friendId]
+            updateData["friendsIdArray"] = newIdArray // 현재 친구목록 + 추가친구 id 더하기
+            
+            let newIdRequestArray = friendsIdRequestArray.filter { $0 != friendId }
+            updateData["friendsIdRequestArray"] = newIdRequestArray
+
+            // 현재 사용자 id, 친구 정보 가져오는거 실패하면 return
+            let opponent: User? = try await UserStore.fetchUser(userId: friendId)
+            guard let userId = currentUser?.id else {
+                return
+            }
+            guard let opponent else {
+                return
+            }
+            try await dbRef.document(userId).updateData(updateData)
+
+            // 친구쪽 추가
+            let updateOpponentData = ["friendsIdArray": opponent.friendsIdArray + [userId]]
+            try await dbRef.document(opponent.id).updateData(updateOpponentData)
+
+            // 다시 친구목록 업데이트
+//            currentUser?.friendsIdArray = newIdArray
+//            friendsIdArray = currentUser?.friendsIdArray ?? []
+            
+            try await fetchFriends()
+            try await fetchFriendsRequest()
+
+        } catch {
+            print("파이어베이스 업데이트 실패")
+        }
+    }
+
+    /// 친구 삭제
+    func removeFriend(friendId: String) async throws {
+        do {
+            try await fetchFriends()
+
+            let newIdArray = friendsIdArray.filter { $0 != friendId }
+            let updateData = ["friendsIdArray": newIdArray]
+
+            // 현재 사용자 id, 친구 정보 가져오는거 실패하면 return
+            let opponent: User? = try await UserStore.fetchUser(userId: friendId)
+            guard let userId = currentUser?.id else {
+                return
+            }
+            guard let opponent else {
+                return
+            }
+
+            // 유저정보 업데이트
+            try await dbRef.document(userId).updateData(updateData)
+            // 친구쪽 삭제
+            let updateOpponentData = ["friendsIdArray": opponent.friendsIdArray.filter { $0 !=  userId}]
+            try await dbRef.document(opponent.id).updateData(updateOpponentData)
+
+            // friendsIdArray 업데이트
+//            currentUser?.friendsIdArray = newIdArray
+//            friendsIdArray = currentUser?.friendsIdArray ?? []
+            
+            try await fetchFriends()
+
+        } catch {
+            print("파이어베이스 업데이트 실패")
+        }
+    }
+
+    /// 친구에게 친구요청
+    func addRequest(friendId: String) async throws {
+
+        do {
+            // 친구의 friendIdrequestArray가져오기
+            let opponent = try await UserStore.fetchUser(userId: friendId)
+            guard let userId = currentUser?.id else {
+                return
+            }
+            guard let opponent else {
+                return
+            }
+            let requestArray = opponent.friendsIdRequestArray
+
+            // 친구 요청목록 업데이트
+            let newIdRequestArray = requestArray + [userId]
+            let updateData = ["friendsIdRequestArray": newIdRequestArray] // 현재 친구목록 + 추가친구 id 더하기
+            
+            try await dbRef.document(friendId).updateData(updateData)
+
+            // 다시 요청목록 업데이트
+//            currentUser?.friendsIdRequestArray = newIdRequestArray
+//            friendsIdRequestArray = currentUser?.friendsIdRequestArray ?? []
+            // 다시 패치
+//            try await self.fetchFriendsRequest()
+            
+        } catch {
+            print("파이어베이스 업데이트 실패")
+        }
+    }
+
+    /// 친구요청 거절
+    func removeRequest(friendId: String) async throws {
+
+        do {
+            try await fetchFriendsRequest()
+
+            guard let userId = currentUser?.id else {
+                return
+            }
+
+            // 요청목록 업데이트
+            let newIdRequestArray = friendsIdRequestArray.filter { $0 != friendId }
+            let updateData = ["friendsIdRequestArray": newIdRequestArray]
+            try await Firestore.firestore().collection("Users").document(userId).updateData(updateData)
+
+            // 다시 요청목록 업데이트
+            currentUser?.friendsIdRequestArray = newIdRequestArray
+            friendsIdRequestArray = currentUser?.friendsIdRequestArray ?? []
+
+            // 다시 패치
+            try await self.fetchFriendsRequest()
+
+        } catch {
+            print("파이어베이스 업데이트 실패")
+        }
+    }
+}

--- a/Zipadoo/Zipadoo/ViewModels/Login/AuthStore.swift
+++ b/Zipadoo/Zipadoo/ViewModels/Login/AuthStore.swift
@@ -94,7 +94,7 @@ final class AuthStore: ObservableObject {
     /// 로그인 스토어 데이터를 받아서 파이어베이스에 보내기 (email, 카카오, 애플)
     func addUserData(id: String, name: String, nickName: String, phoneNumber: String, profileImageString: String) async throws {
         do {
-            let user = User(id: id, name: name, nickName: nickName, phoneNumber: phoneNumber, potato: 0, profileImageString: profileImageString, crustDepth: 0, tardyCount: 0)
+            let user = User(id: id, name: name, nickName: nickName, phoneNumber: phoneNumber, potato: 0, profileImageString: profileImageString, crustDepth: 0, tardyCount: 0, friendsIdArray: [], friendsIdRequestArray: [])
             try dbRef.document(id).setData(from: user)
             
         } catch {

--- a/Zipadoo/Zipadoo/Views/Friends/FriendsRegistrationView.swift
+++ b/Zipadoo/Zipadoo/Views/Friends/FriendsRegistrationView.swift
@@ -9,17 +9,20 @@ import SwiftUI
 
 struct FriendsRegistrationView: View {
     
+    @ObservedObject var friendsStore: FriendsStore
     @Environment(\.dismiss) private var dismiss
     
     /// 친구 닉네임
     @State private var nickNameTextField: String = ""
+    /// 알람 노출유무
+    @State private var isShowingAlert: Bool = false
     /*
     /// 친구 연락처
     @State private var phoneTextField: String = ""
     */
     
     var body: some View {
-        VStack {
+        VStack(alignment: .leading) {
             TextField("친구의 닉네임을 입력해주세요.", text: $nickNameTextField)
                 .padding(10)
                 .overlay(
@@ -27,6 +30,13 @@ struct FriendsRegistrationView: View {
                         .stroke(.gray)
                 )
                 .padding(.bottom, 5)
+            
+            // 해당하는 닉네임이 없으면 알람메세지
+            if !friendsStore.alertMessage.isEmpty {
+                Text("\(friendsStore.alertMessage)")
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
             /*
             TextField("친구의 연락처를 입력해주세요.", text: $phoneTextField)
                 .padding(10)
@@ -43,14 +53,41 @@ struct FriendsRegistrationView: View {
                 Button {
                     // 추가성공 -> dismiss
                     // 추가실패 -> 현 페이지 머물기, 그런 사람 없다고 밑에 안내문구
+                    Task {
+                        try await friendsStore.findFriend(friendNickname: nickNameTextField) { resultBool in
+                            if resultBool { // 추가할 수 있으면 알람
+                                friendsStore.alertMessage = ""
+                                isShowingAlert.toggle()
+                                
+                            }
+                        }
+                    }
+                    
                 } label: {
                     Text("추가")
                 }
             }
         }
+        .alert(isPresented: $isShowingAlert, content: {
+            
+            Alert(
+                title: Text(""),
+                message: Text("친구를 요청합니다"),
+                dismissButton: .default(Text("확인"), action: {
+                    isShowingAlert = false
+                    dismiss()
+                    friendsStore.alertMessage = ""
+                })
+            )
+        })
+        .onAppear {
+            friendsStore.alertMessage = ""
+        }
     }
 }
 
 #Preview {
-    FriendsRegistrationView()
+    NavigationStack {
+        FriendsRegistrationView(friendsStore: FriendsStore())
+    }
 }


### PR DESCRIPTION
## 🚀관련 이슈
- close #125 

## ✨작업 내용
- 친구목록뷰 삭제 버튼 파베 연결
- 친구요청뷰 수락, 거절 버튼 파베 연결
- 친구의 닉네임 검색 후 친구 요청 ( 자신의 닉네임입력한 경우/ 이미 친구인 경우/ 이미 요청한 경우 친구요청 불가)

## 📸 스크린샷
<img  width="20%" src="https://github.com/APPSCHOOL3-iOS/final-zipadoo/assets/102401977/9ac14489-7c97-4f52-a92f-82dc6a4e9768"/>
<img width="20%" src="https://github.com/APPSCHOOL3-iOS/final-zipadoo/assets/102401977/0c71916a-5d5a-42f0-a489-7509de05cb08">
<img width="20%" src="https://github.com/APPSCHOOL3-iOS/final-zipadoo/assets/102401977/313111c2-938a-4190-9c9d-af60ce85b835">
<br>
<br>
friend계정에서 gushed를 친구로 요청한 뒤 gushed계정으로 다시 로그인해 친구요청 수락 -> 친구목록에 추가됨
<br>
<img width="20%" src="https://github.com/APPSCHOOL3-iOS/final-zipadoo/assets/102401977/6cd81c4b-08e1-4fa6-81c6-b3c3fec9c7ad">
<img width="20%" src="https://github.com/APPSCHOOL3-iOS/final-zipadoo/assets/102401977/1fd6cff5-ded1-4e62-8a66-1d96d4089b35">
<img width="20%" src="https://github.com/APPSCHOOL3-iOS/final-zipadoo/assets/102401977/38de1ac3-edc3-4f34-8790-776f8e92f445">

## 📝참고 사항
- 회원가입할 때 닉네임중복 확인 추가할 예정
- 친구요청 알람에 취소 버튼 추가 예정
