### PR TITLE
[FIX] 계정 삭제 기능 추가

### DIFF
--- a/Zipadoo/Zipadoo.xcodeproj/project.pbxproj
+++ b/Zipadoo/Zipadoo.xcodeproj/project.pbxproj
@@ -186,7 +186,7 @@
 		3F6C02902B0ED3FA00FCA74B /* SlidingTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlidingTabView.swift; sourceTree = "<group>"; };
 		3F6D17932B039919007C8998 /* ProgressSubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressSubView.swift; sourceTree = "<group>"; };
 		3F6D17952B0399F4007C8998 /* PromiseTitleAndTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromiseTitleAndTimeView.swift; sourceTree = "<group>"; };
-		3F7487522B1F503E0026B38F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Desktop/Documentation/지파두/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		3F7487522B1F503E0026B38F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3FF033042ADD30C800FF13A5 /* AppInfoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppInfoView.swift; sourceTree = "<group>"; };
 		3FF033082ADD318300FF13A5 /* DeveloperProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperProfileView.swift; sourceTree = "<group>"; };
 		8B3E66D12AE267E6003EE83E /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };

--- a/Zipadoo/Zipadoo/Enum/Enum.swift
+++ b/Zipadoo/Zipadoo/Enum/Enum.swift
@@ -74,3 +74,7 @@ enum PromiseCellType {
         }
     }
 }
+
+enum AuthError: Error {
+    case userNotLoggedIn
+}

--- a/Zipadoo/Zipadoo/Extention/Extention.swift
+++ b/Zipadoo/Zipadoo/Extention/Extention.swift
@@ -59,7 +59,6 @@ extension View {
                     .foregroundColor(.secondary.opacity(0.7)))
             }
         }
-        .keyboardType(.numberPad)
         .font(.title3)
         .fontWeight(.semibold)
         .autocapitalization(.none) // 소문자로 시작

--- a/Zipadoo/Zipadoo/Extention/Extention.swift
+++ b/Zipadoo/Zipadoo/Extention/Extention.swift
@@ -10,6 +10,7 @@ import CoreLocation
 import Foundation
 import MapKit
 import SwiftUI
+import FirebaseAuth
 
 // View의 Extension
 extension View {
@@ -58,6 +59,7 @@ extension View {
                     .foregroundColor(.secondary.opacity(0.7)))
             }
         }
+        .keyboardType(.numberPad)
         .font(.title3)
         .fontWeight(.semibold)
         .autocapitalization(.none) // 소문자로 시작
@@ -244,3 +246,17 @@ extension PromiseTitleAndTimeView {
         }
     }
 }
+
+extension AuthStore {
+    @MainActor
+    func reauthenticate(email: String, password: String) async throws {
+        guard let user = Auth.auth().currentUser else {
+            // Handle the case where the user is not logged in
+            throw AuthError.userNotLoggedIn
+        }
+
+        let credential = EmailAuthProvider.credential(withEmail: email, password: password)
+        try await user.reauthenticate(with: credential)
+    }
+}
+

--- a/Zipadoo/Zipadoo/Views/Friends/FriendsRegistrationView.swift
+++ b/Zipadoo/Zipadoo/Views/Friends/FriendsRegistrationView.swift
@@ -23,6 +23,7 @@ struct FriendsRegistrationView: View {
                 HStack {
                     TextField("친구의 닉네임을 입력해주세요.", text: $nickNameTextField)
                         .padding(10)
+                        .autocapitalization(.none)
                         .autocorrectionDisabled()
                     
                     Button {

--- a/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/NewMapViews/SearchbarCell.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/NewMapViews/SearchbarCell.swift
@@ -44,6 +44,7 @@ struct SearchBarCell: View {
                 // 장소(키워드) 입력창
                 TextField(textFieldText, text: $searchText)
                     .textFieldStyle(.roundedBorder)
+                    .autocapitalization(.none)
                     .autocorrectionDisabled()
                 // Search 버튼
                 Button {

--- a/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/OneAddLocation.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/OneAddLocation.swift
@@ -40,6 +40,7 @@ struct OneAddLocation: View {
                                     .textFieldStyle(.roundedBorder)
                                     .padding(.horizontal)
                                     .frame(height: 30)
+                                    .autocapitalization(.none)
                                     .autocorrectionDisabled()
                             // MARK: - 화면을 클릭해서 장소를 선택한 값이 false라면 "약속 장소를 선택해 주세요" 텍스트를 표시함
                             } else {

--- a/Zipadoo/Zipadoo/Views/Home/AddPromise/AddPromiseView.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPromise/AddPromiseView.swift
@@ -69,6 +69,7 @@ struct AddPromiseView: View {
                     
                     HStack {
                         TextField("약속 이름을 입력해주세요.", text: $promiseTitle)
+                            .autocapitalization(.none)
                             .fontWeight(.semibold)
                             .onChange(of: promiseTitle) {
                                 if promiseTitle.count > 15 {

--- a/Zipadoo/Zipadoo/Views/Home/PromiseEditView.swift
+++ b/Zipadoo/Zipadoo/Views/Home/PromiseEditView.swift
@@ -244,6 +244,7 @@ struct PromiseEditView: View {
                     TextField("약속 이름을 수정해주세요", text: $editedPromiseTitle)
                         .fontWeight(.semibold)
                         .autocorrectionDisabled()
+                        .autocapitalization(.none)
                         .onChange(of: editedPromiseTitle) {
                             if editedPromiseTitle.count > 15 { editedPromiseTitle = String(editedPromiseTitle.prefix(15)) }
                         }

--- a/Zipadoo/Zipadoo/Views/Login/LoginView.swift
+++ b/Zipadoo/Zipadoo/Views/Login/LoginView.swift
@@ -76,17 +76,17 @@ struct LoginView: View {
                             .disabled(true)
                              */
                             // MARK: - 애플 로그인 버튼
-                            Button {
-                                print("apple login")
-                            } label: {
-                                // 다크모드 아니면 애플버튼 색 반전
-                                if colorScheme == .dark {
-                                    imageAndLoginButtonView("apple_login")
-                                } else {
-                                    imageAndLoginButtonView("apple_login")
-                                        .colorInvert()
-                                }
-                            }
+//                            Button {
+//                                print("apple login")
+//                            } label: {
+//                                // 다크모드 아니면 애플버튼 색 반전
+//                                if colorScheme == .dark {
+//                                    imageAndLoginButtonView("apple_login")
+//                                } else {
+//                                    imageAndLoginButtonView("apple_login")
+//                                        .colorInvert()
+//                                }
+//                            }
                              
                             // 두더지 몸통
                             Rectangle()

--- a/Zipadoo/Zipadoo/Views/Login/SigninByEmailView.swift
+++ b/Zipadoo/Zipadoo/Views/Login/SigninByEmailView.swift
@@ -107,6 +107,7 @@ struct SigninByEmailView: View {
                 Group {
                     HStack {
                         loginTextFieldView($emailLoginStore.phoneNumber, "휴대폰 번호", isvisible: true)
+                            .keyboardType(.numberPad)
                         
                         eraseButtonView($emailLoginStore.phoneNumber)
                     } // HStack

--- a/Zipadoo/Zipadoo/Views/MyPageViews/EditProfilView.swift
+++ b/Zipadoo/Zipadoo/Views/MyPageViews/EditProfilView.swift
@@ -13,6 +13,7 @@ struct EditProfileView: View {
     private let loginEmailCheckView = LoginEmailCheckView()
     private let signinByEmailView = SigninByEmailView(emailLoginStore: EmailLoginStore())
     @ObservedObject var emailLoginStore: EmailLoginStore
+    @StateObject var viewModel = ContentViewModel()
     /// 비밀번호 보이기
     @State private var isPasswordVisible = false
     /// 형식 유효메세지
@@ -21,6 +22,8 @@ struct EditProfileView: View {
     @State private var isOverlapNickname = false
     /// 닉네임 중복 유효메세지 노출유무
     @State private var isPresentedMessage = false
+    /// 회원탈퇴 알럿
+    @State private var isDeleteUserDataAlert = false
     /// 닉네임 중복 유효메세지
     @State private var nicknameOverlapMessage = ""
     /// 닉네임 중복 유효 메세지 글자색
@@ -49,113 +52,140 @@ struct EditProfileView: View {
     }
     
     var body: some View {
-        ScrollView {
-            VStack {
-                Button {
-                    isShowingImagePicker.toggle()
-                } label: {
-                    // 프로필 사진 선택할 경우 프로필 사진으로 표시, 아닐 경우 파이어베이스에 저장된 이미지 보이도록
-                    
-                    if let profileImage = selectedImage {
-                        Image(uiImage: profileImage)
-                            .resizable()
-                            .scaledToFill()
-                            .frame(width: 150, height: 150)
-                            .clipShape(Circle())
-                    } else {
-                        ProfileImageView(imageString: userStore.getUserProfileImage(), size: .medium)
-                    }
-                }
-                .sheet(isPresented: $isShowingImagePicker) {
-                    ImagePicker(selectedImage: $selectedImage)
-                        .ignoresSafeArea(.all)
-                }
-                .frame(width: UIScreen.main.bounds.size.width, height: 200)
-                .background(.gray)
+        VStack {
+            Button {
+                isShowingImagePicker.toggle()
+            } label: {
+                // 프로필 사진 선택할 경우 프로필 사진으로 표시, 아닐 경우 파이어베이스에 저장된 이미지 보이도록
                 
-                VStack(alignment: .leading) {
-                    Group {
-                        HStack {
-                            loginTextFieldView($emailLoginStore.nickName, nickname, isvisible: true)
-                            
-                            // 입력한 내용 지우기 버튼
-                            eraseButtonView($emailLoginStore.nickName)
-                        }
-                        .onChange(of: emailLoginStore.nickName) { newValue in
-                            let filtered = newValue.filter { $0.isLetter || $0.isNumber }
-                            nickNameMessage = filtered != newValue ? "특수문자는 입력할 수 없습니다." : ""
-                        }
-                        underLine()
+                if let profileImage = selectedImage {
+                    Image(uiImage: profileImage)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 150, height: 150)
+                        .clipShape(Circle())
+                } else {
+                    ProfileImageView(imageString: userStore.getUserProfileImage(), size: .medium)
+                }
+            }
+            .sheet(isPresented: $isShowingImagePicker) {
+                ImagePicker(selectedImage: $selectedImage)
+                    .ignoresSafeArea(.all)
+            }
+            .frame(width: UIScreen.main.bounds.size.width, height: 200)
+            .background(.gray)
+            
+            VStack(alignment: .leading) {
+                Group {
+                    HStack {
+                        loginTextFieldView($emailLoginStore.nickName, nickname, isvisible: true)
                         
-                        VStack(alignment: .leading) {
-                            Text(nickNameMessage)
-                                .foregroundColor(.red)
-                                .font(.subheadline)
-                                .opacity(0.7)
-                            
-                            if isPresentedMessage {
-                                Text(nicknameOverlapMessage)
-                                    .modifier(LoginMessageStyle(color: nicknameMessageColor))
-                            }
-                        }
+                        // 입력한 내용 지우기 버튼
+                        eraseButtonView($emailLoginStore.nickName)
                     }
-                    .padding(.top, 20)
+                    .onChange(of: emailLoginStore.nickName) { newValue in
+                        let filtered = newValue.filter { $0.isLetter || $0.isNumber }
+                        nickNameMessage = filtered != newValue ? "특수문자는 입력할 수 없습니다." : ""
+                    }
+                    underLine()
                     
-                    Group {
-                        HStack {
-                            loginTextFieldView($emailLoginStore.phoneNumber, phoneNumber, isvisible: true)
-                            
-                            // 입력한 내용 지우기 버튼
-                            eraseButtonView($emailLoginStore.phoneNumber)
-                        }
-                        .onChange(of: emailLoginStore.phoneNumber) { newValue in
-                            let filtered = newValue.filter { $0.isNumber }
-                            numberMessage = filtered != newValue ? "숫자만 입력해주세요" : ""
-                        }
-                        underLine()
-                        
-                        Text(numberMessage)
+                    VStack(alignment: .leading) {
+                        Text(nickNameMessage)
                             .foregroundColor(.red)
                             .font(.subheadline)
                             .opacity(0.7)
-                    }
-                    .padding(.top, 20)
-                }
-                .padding()
-            }
-            .navigationTitle("회원정보 수정")
-            .navigationBarTitleDisplayMode(.inline)
-            .onAppear {
-                nickname = userStore.currentUser?.nickName ?? ""
-                phoneNumber = userStore.currentUser?.phoneNumber ?? ""
-            }
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        checkValid()
-                        //                        isEditAlert.toggle()
-                    } label: {
-                        Text("수정")
-                    }
-                    .disabled(isFieldEmpty || !isValid) // 필드가 하나라도 비어있으면 비활성화
-                }
-            }
-            .alert(isPresented: $isEditAlert) {
-                Alert(
-                    title: Text(""),
-                    message: Text("회원정보가 수정됩니다"),
-                    primaryButton: .default(Text("취소"), action: {
-                        isEditAlert = false
-                    }),
-                    secondaryButton: .destructive(Text("수정"), action: {
-                        isEditAlert = false
-                        dismiss()
-                        Task {
-                            try await userStore.updateUserData(image: selectedImage, nick: emailLoginStore.nickName, phone: emailLoginStore.phoneNumber)
+                        
+                        if isPresentedMessage {
+                            Text(nicknameOverlapMessage)
+                                .modifier(LoginMessageStyle(color: nicknameMessageColor))
                         }
-                    })
-                )
+                    }
+                }
+                .padding(.top, 20)
+                
+                Group {
+                    HStack {
+                        loginTextFieldView($emailLoginStore.phoneNumber, phoneNumber, isvisible: true)
+                        
+                        // 입력한 내용 지우기 버튼
+                        eraseButtonView($emailLoginStore.phoneNumber)
+                    }
+                    .onChange(of: emailLoginStore.phoneNumber) { newValue in
+                        let filtered = newValue.filter { $0.isNumber }
+                        numberMessage = filtered != newValue ? "숫자만 입력해주세요" : ""
+                    }
+                    underLine()
+                    
+                    Text(numberMessage)
+                        .foregroundColor(.red)
+                        .font(.subheadline)
+                        .opacity(0.7)
+                }
+                .padding(.top, 20)
             }
+            .padding()
+            
+            Spacer()
+            
+            Button {
+                isDeleteUserDataAlert = true
+            } label: {
+                Text("회원 탈퇴")
+                    .underline()
+            }
+            .tint(.red)
+            .padding(.bottom, 10)
+        }
+        .navigationTitle("회원정보 수정")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            nickname = userStore.currentUser?.nickName ?? ""
+            phoneNumber = userStore.currentUser?.phoneNumber ?? ""
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    checkValid()
+                    isEditAlert = true
+                } label: {
+                    Text("수정")
+                }
+                .disabled(isFieldEmpty || !isValid) // 필드가 하나라도 비어있으면 비활성화
+            }
+        }
+        .alert(isPresented: $isEditAlert) {
+            Alert(
+                title: Text(""),
+                message: Text("회원정보가 수정됩니다"),
+                primaryButton: .default(Text("취소"), action: {
+                    isEditAlert = false
+                }),
+                secondaryButton: .destructive(Text("수정"), action: {
+                    isEditAlert = false
+                    dismiss()
+                    Task {
+                        try await userStore.updateUserData(image: selectedImage, nick: emailLoginStore.nickName, phone: emailLoginStore.phoneNumber)
+                    }
+                })
+            )
+        }
+        .alert(isPresented: $isDeleteUserDataAlert) {
+            Alert(
+                title: Text("정말로 회원 탈퇴 하시겠습니까?"),
+                message: Text("회원 정보가 즉시 삭제됩니다"),
+                primaryButton: .default(Text("취소"), action: {
+                    isDeleteUserDataAlert = false
+                }),
+                secondaryButton: .destructive(Text("회원 탈퇴"), action: {
+                    Task {
+                        do {
+                            try await AuthStore.shared.deleteAccount()
+                        } catch {
+                            print("회원 탈퇴 실패: \(error.localizedDescription)")
+                        }
+                    }
+                })
+            )
         }
     }
     
@@ -164,10 +194,10 @@ struct EditProfileView: View {
             Text(title)
             TextField("", text: text)
                 .textFieldStyle(.roundedBorder)
+                .autocapitalization(.none)
                 .autocorrectionDisabled()
         }
     }
-    
     private func checkValid() {
         // 파베 중복확인 : 중복시 true
         Task {


### PR DESCRIPTION
## 🚀관련 이슈
- <fix> #384 

## ✨작업 내용
- 마이페이지뷰의 회원정보 수정 클릭한 후 하단의 버튼을 통해 회원탈퇴 가능
  - 회원정보 수정뷰에서 스크롤 뷰가 필요가 없을것 같아 ScrollView 삭제
  - 회원탈퇴 텍스트에 밑줄이 그어진 디자인의 버튼
  - 회원 탈퇴 시 알럿이 나오고 회원탈퇴를 누를 시 회원탈퇴 처리됨
  - 그로인해 친구들 목록에서도 사라지며 예정된 약속에서도 없어짐
  - 회원탈퇴 후 가입했던 이메일로 다시 회원가입 가능하도록 구현
  - 회원탈퇴후 친구목록에도 남아있거나 친구가 한명인 상태에서 그 친구가 회원탈퇴할 경우 흰 화면만 있는 이슈도 있었음

- 그외 텍스트필드 키보드 입력 디폴트를 소문자로 변경
  - 회원가입 시 전화번호 입력을 숫자 키보드 배열로 변경
- 로그인뷰에서 애플 로그인 버튼 주석처리

## 📸 스크린샷
### iPhone SE
<img width="40%" src="https://github.com/APP-iOS2/final-zipadoo/assets/134041539/d2db1a3e-df07-42a6-be17-6d8da8f08770"/>
<img width="40%" src="https://github.com/APP-iOS2/final-zipadoo/assets/134041539/28f275f4-aab7-4295-9714-d4ae4c566378"/>

### iPhone 15 Pro
<img width="40%" src="https://github.com/APP-iOS2/final-zipadoo/assets/134041539/dbbe95d8-5114-4675-8645-5246decb1e7d"/>
