### PR TITLE
[FIX] 약속장소 검색 시 카테고리 안보이는 사항 수정

### DIFF
--- a/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/NewMapViews/AddPlaceButtonCell.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/NewMapViews/AddPlaceButtonCell.swift
@@ -45,7 +45,7 @@ struct AddPlaceButtonCell: View {
                                             .foregroundStyle(.white, .red)
                                     }
                                     .shadow(radius: 5)
-                                    .padding(.top, 2)
+                                    .padding(.top, 5)
                                     .padding(.trailing, 6)
                                 }
                                 Spacer()

--- a/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/NewMapViews/SearchbarCell.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/NewMapViews/SearchbarCell.swift
@@ -159,11 +159,15 @@ struct SearchBarCell: View {
             }
         }
     }
+    
     private func category(categoryName: String) -> String {
-        let firstI = categoryName.index(after: categoryName.lastIndex(of: ">") ?? categoryName.endIndex)
-        let lastI = categoryName.index(before: categoryName.endIndex)
-        
-        return String(categoryName[firstI...lastI])
+        if let greaterThanIndex = categoryName.lastIndex(of: ">") {
+            let firstI = categoryName.index(after: greaterThanIndex)
+            let lastI = categoryName.index(before: categoryName.endIndex)
+            return String(categoryName[firstI...lastI])
+        } else {
+            return categoryName
+        }
     }
 }
 

--- a/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/NewMapViews/SearchbarCell.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/NewMapViews/SearchbarCell.swift
@@ -19,9 +19,9 @@ struct SearchBarCell: View {
     /// 검색버튼에 의한 리스트 도출 값
     @State var searching: Bool = false
     /// accuracy: 정렬기준
-    @State private var sort: String = "accuracy" // distance
-    /// 거리로 부터 5000m내의 검색결과 제공(잘 안되는것 같음)
-    @State private var radius: Int = 5000
+    @State private var sort: String = "accuracy" // distance / accuracy
+    /// 거리로 부터 20km내의 검색결과 제공(잘 안되는것 같음)
+    @State private var radius: Int = 20000
     /// 장소에 대한 URL 값 (카카오맵 기반)
     @State private var placeURL: String?
     /// 검색 결과 리스트의 i 버튼 클릭 값
@@ -112,26 +112,26 @@ struct SearchBarCell: View {
                         } label: {
                             VStack(alignment: .leading) {
                                 HStack {
-                                    VStack {
-                                        HStack {
-                                            Text(result.place_name)
-                                                .font(.headline)
-                                                .foregroundColor(.primary)
-                                            Text(result.category_group_name)
-                                                .font(.caption).bold()
-                                                .foregroundColor(.blue)
-                                            Spacer()
-                                        }
-                                        .padding(.bottom, 5)
-                                        
-                                        HStack {
-                                            Text(result.road_address_name)
+                                    VStack(alignment: .leading) {
+                                            HStack {
+                                                Text(result.place_name.count > 14 ? result.place_name.prefix(14) + "..." : result.place_name)
+                                                    .font(.headline)
+                                                  
+                                                Text(category(categoryName: result.category_name))
+                                                    .font(.caption).bold()
+                                                    .foregroundColor(.blue)
+                                                    .padding(.bottom, -3)
+                                                    .padding(.leading, -7)
+                                                
+                                                Spacer()
+                                            }
+                                            .foregroundColor(.primary)
+                                            
+                                            Text(result.road_address_name.isEmpty ? result.address_name : result.road_address_name)
                                                 .font(.subheadline)
-                                                .foregroundColor(.primary)
-                                            Spacer()
+                                            
                                         }
-                                    }
-                                    Spacer()
+//                                        .padding(.bottom, 5)
                                     
                                     /// ( i ) 버튼을 누르면 검색을 통해 얻은 url값으로 더 자세한 정보가 담긴 카카오맵 웹뷰 시트가 띄어짐
                                     Button {
@@ -153,9 +153,17 @@ struct SearchBarCell: View {
                     }
                 }
                 .listStyle(.plain)
-                .navigationBarBackButtonHidden(true)
+                .scrollIndicators(.hidden)
+                .padding(.bottom)
+                .cornerRadius(5, corners: .allCorners)
             }
         }
+    }
+    private func category(categoryName: String) -> String {
+        let firstI = categoryName.index(after: categoryName.lastIndex(of: ">") ?? categoryName.endIndex)
+        let lastI = categoryName.index(before: categoryName.endIndex)
+        
+        return String(categoryName[firstI...lastI])
     }
 }
 

--- a/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/NewMapViews/SearchbarCell.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/NewMapViews/SearchbarCell.swift
@@ -18,15 +18,14 @@ struct SearchBarCell: View {
     @State private var searchText: String = ""
     /// 검색버튼에 의한 리스트 도출 값
     @State var searching: Bool = false
-    /// accuracy: 정렬기준
-    @State private var sort: String = "accuracy" // distance / accuracy
-    /// 거리로 부터 20km내의 검색결과 제공(잘 안되는것 같음)
+    /// 거리로 부터 20km내의 검색결과 제공
     @State private var radius: Int = 20000
     /// 장소에 대한 URL 값 (카카오맵 기반)
     @State private var placeURL: String?
     /// 검색 결과 리스트의 i 버튼 클릭 값
     @State private var clickedPlaceInfo: Bool = false
     @State private var textFieldText: String = "키워드를 입력하세요."
+//    @State private var myLocation: Bool = false
     
     var locationManager: LocationManager = LocationManager()
     @Binding var selectedPlace: Bool
@@ -53,10 +52,9 @@ struct SearchBarCell: View {
                         isClickedPlace = false
                         selectedPlace = false
                         // 카카오로컬 API를 활용하여 카카오로컬에 담긴 JSON파일과 통신하여 데이터를 불러옴
-                        searchOfKakaoLocal.searchKLPlace(keyword: searchText, currentPoiX: String(locationManager.location?.coordinate.latitude ?? 0.0), currentPoiY: String(locationManager.location?.coordinate.longitude ?? 0.0), radius: radius, sort: sort)
+                        searchOfKakaoLocal.searchKLPlace(keyword: searchText, currentPoiX: String(locationManager.location?.coordinate.latitude ?? 0.0), currentPoiY: String(locationManager.location?.coordinate.longitude ?? 0.0), radius: radius, sort: /*myLocation ? "distance" : */"accuracy")
                         print("현재 사용자 위도(장소검색): \(locationManager.location?.coordinate.latitude ?? 0.0)")
                         print("현재 사용자 경도(장소검색): \(locationManager.location?.coordinate.longitude ?? 0.0)")
-                        
                     } else { // searchText가 빈 값일 경우 해당 텍스트를 보여줌
                         textFieldText = "한 글자 이상 입력해주세요."
                     }
@@ -74,6 +72,34 @@ struct SearchBarCell: View {
             
             /// 검색버튼을 눌렀을 경우, searching값이 true가 되어 검색결과에 대한 리스트값 도출
             if searching == true {
+                HStack {
+                    Button {
+//                        myLocation = false
+                        searching = false
+                        searchText = ""
+                    } label: {
+                        Text("취소")
+                    }
+                    .tint(.red)
+                    .padding(.leading, 5)
+                    
+                    Spacer()
+                    
+//                    Text("내 주변")
+//                    Button {
+//                        myLocation.toggle()
+//                        searchOfKakaoLocal.searchKLPlace(keyword: searchText, currentPoiX: String(locationManager.location?.coordinate.latitude ?? 0.0), currentPoiY: String(locationManager.location?.coordinate.longitude ?? 0.0), radius: radius, sort: myLocation ? "distance" : "accuracy")
+//                    } label: {
+//                        Image(systemName: myLocation ? "checkmark.square.fill" : "checkmark.square")
+//                            .resizable()
+//                            .scaledToFit()
+//                            .frame(width: 15, height: 15)
+//                    }
+//                    .tint(.mocha)
+//                    .padding(.trailing, 5)
+                }
+                .padding(.top, -10)
+                
                 List(searchOfKakaoLocal.searchKakaoLocalDatas, id: \.place_name) { result in
                     VStack {
                         Button {
@@ -108,30 +134,31 @@ struct SearchBarCell: View {
                             textFieldText = "키워드를 입력하세요."
                             selectedPlace = false
                             searching = false
+//                            myLocation = false
                             hideKeyboard()
                         } label: {
                             VStack(alignment: .leading) {
                                 HStack {
                                     VStack(alignment: .leading) {
-                                            HStack {
-                                                Text(result.place_name.count > 14 ? result.place_name.prefix(14) + "..." : result.place_name)
-                                                    .font(.headline)
-                                                  
-                                                Text(category(categoryName: result.category_name))
-                                                    .font(.caption).bold()
-                                                    .foregroundColor(.blue)
-                                                    .padding(.bottom, -3)
-                                                    .padding(.leading, -7)
-                                                
-                                                Spacer()
-                                            }
-                                            .foregroundColor(.primary)
+                                        HStack {
+                                            Text(result.place_name.count > 14 || (result.place_name.count + category(categoryName: result.category_name).count > 23) || (result.place_name.count > 14 && category(categoryName: result.category_name).count > 10) ? result.place_name.prefix(13) + "..." : result.place_name)
+                                                .font(.headline)
                                             
-                                            Text(result.road_address_name.isEmpty ? result.address_name : result.road_address_name)
-                                                .font(.subheadline)
+                                            Text(category(categoryName: result.category_name))
+                                                .font(.caption).bold()
+                                                .foregroundColor(.blue)
+                                                .padding(.bottom, -3)
+                                                .padding(.leading, -7)
                                             
+                                            Spacer()
                                         }
-//                                        .padding(.bottom, 5)
+                                        .foregroundColor(.primary)
+                                        
+                                        Text(result.road_address_name.isEmpty ? result.address_name : result.road_address_name)
+                                            .font(.subheadline)
+                                        
+                                    }
+                                    //                                        .padding(.bottom, 5)
                                     
                                     /// ( i ) 버튼을 누르면 검색을 통해 얻은 url값으로 더 자세한 정보가 담긴 카카오맵 웹뷰 시트가 띄어짐
                                     Button {
@@ -144,6 +171,7 @@ struct SearchBarCell: View {
                                             .frame(width: 30)
                                     }
                                     .tint(.mocha)
+                                    .padding(.trailing, -7)
                                     .fullScreenCover(item: $placeURL) { url in
                                         PlaceInfoWebView(urlString: url)
                                     }
@@ -155,11 +183,12 @@ struct SearchBarCell: View {
                 .listStyle(.plain)
                 .scrollIndicators(.hidden)
                 .padding(.bottom)
-                .cornerRadius(5, corners: .allCorners)
+                .cornerRadius(5, corners: .bottomLeft)
+                .cornerRadius(5, corners: .bottomRight)
             }
         }
     }
-    
+    /// 제일 마지막 부분의 카테고리를 표시하게 해주는 함수
     private func category(categoryName: String) -> String {
         if let greaterThanIndex = categoryName.lastIndex(of: ">") {
             let firstI = categoryName.index(after: greaterThanIndex)

--- a/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/SearchInKakaoLocal.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/SearchInKakaoLocal.swift
@@ -93,7 +93,9 @@ class SearchOfKakaoLocal: ObservableObject {
                                 }
                             }
                             
-                            lists.sort(by: { $0.distance < $1.distance })
+//                            if sort == "distance" {
+//                                lists.sort(by: { $0.distance < $1.distance })
+//                            }
                             
                             DispatchQueue.main.async {
                                 self.searchKakaoLocalDatas = lists

--- a/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/SearchInKakaoLocal.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/SearchInKakaoLocal.swift
@@ -10,16 +10,9 @@ import MapKit
 import Alamofire
 
 struct MetaInfo: Codable {
-    let total_count: Int
-    let pageable_count: Int
-    let is_end: Bool
-    let same_name: SameNameInfo
-}
-
-struct SameNameInfo: Codable {
-    let region: [String]
-    let keyword: String
-    let selected_region: String
+    var total_count: Int
+    var pageable_count: Int
+    var is_end: Bool
 }
 
 // MARK: - 카카오로컬 기반 장소 검색 데이터 구조체
@@ -42,7 +35,7 @@ struct KakaoLocalData: Identifiable, Codable {
 /// 검색 설정 맵뷰에서 카카오로컬을 기반의 검색 기능에서 가져오는 장소 검색 데이터를 불러오는 통신 함수를 포함한 class
 class SearchOfKakaoLocal: ObservableObject {
     static let sharedInstance = SearchOfKakaoLocal()
-    @Published var metaInfo: MetaInfo?
+    @Published var metaInfos: MetaInfo?
     /// 검색 결과에 대한 결과값들이 담긴 리스트 배열
     @Published var searchKakaoLocalDatas: [KakaoLocalData] = []
     
@@ -64,19 +57,39 @@ class SearchOfKakaoLocal: ObservableObject {
         
         func fetchData() {
             var lists: [KakaoLocalData] = []
-            searchKakaoLocalDatas = lists
-            AF.request("https://dapi.kakao.com/v2/local/search/keyword.json", method: .get, parameters: parameters, headers: headers)
+            var metaInfo = MetaInfo(total_count: 0, pageable_count: 0, is_end: false)
+            self.metaInfos = metaInfo
+            
+            searchKakaoLocalDatas = lists //y=\(currentPoiX)&x=\(currentPoiX)&radius=\(radius)
+            AF.request("https://dapi.kakao.com/v2/local/search/keyword.json?", method: .get, parameters: parameters, headers: headers)
                 .validate()
                 .responseJSON(completionHandler: { response in
                     switch response.result {
                     case .success(let value):
                         if let json = value as? [String: Any],
                            let documents = json["documents"] as? [[String: Any]],
-                           let meta = json["meta"] as? [String: Any],
-                           let metaInfoData = try? JSONSerialization.data(withJSONObject: meta),
-                           let metaInfo = try? JSONDecoder().decode(MetaInfo.self, from: metaInfoData) {
-                            self.metaInfo = metaInfo
-                            
+                           let meta = json["meta"] as? [String: Any] {
+                            // Decode MetaInfo
+
+//                            for (key, value) in meta {
+//                                switch key {
+//                                case "total_count":
+//                                    if let totalcount = value as? Int {
+//                                        self.metaInfos?.total_count = totalcount
+//                                    }
+//                                case "pageable_count":
+//                                    if let pageablecount = value as? Int {
+//                                        self.metaInfos?.pageable_count = pageablecount
+//                                    }
+//                                case "is_end":
+//                                    if let isend = value as? Bool {
+//                                        self.metaInfos?.is_end = isend
+//                                    }
+//                                default:
+//                                    break
+//                                }
+//                            }
+                             
                             for item in documents {
                                 if let id = item["id"] as? String,
                                    let placeName = item["place_name"] as? String,
@@ -89,17 +102,18 @@ class SearchOfKakaoLocal: ObservableObject {
                                    let categoryGroupName = item["category_group_name"] as? String,
                                    let placeUrl = item["place_url"] as? String,
                                    let distance = item["distance"] as? String {
+                                    
                                     lists.append(KakaoLocalData(id: id, place_name: placeName, address_name: addressName, road_address_name: roadAdressName, x: x, y: y, phone: phone, category_name: categoryName, category_group_name: categoryGroupName, place_url: placeUrl, distance: distance))
                                 }
                             }
                             
-//                            if sort == "distance" {
-//                                lists.sort(by: { $0.distance < $1.distance })
-//                            }
-                            
                             DispatchQueue.main.async {
                                 self.searchKakaoLocalDatas = lists
                             }
+                            
+//                            print("Total Count: \(self.metaInfos?.total_count ?? 0)")
+//                            print("Pageable Count: \(self.metaInfos?.pageable_count ?? 0)")
+//                            print("Is End: \(self.metaInfos?.is_end ?? false)")
                             
                         } else {
                             print("불러오기 실패")

--- a/Zipadoo/Zipadoo/Views/Home/AddPromise/AddPromiseView.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPromise/AddPromiseView.swift
@@ -317,6 +317,7 @@ struct AddPromiseView: View {
         } // 날짜/시간 선택 sheet
         .sheet(isPresented: $isShowAddPlaceMapSheet) {
             OneMapView(promiseViewModel: promiseViewModel, destination: $destination, address: $address, coordXXX: $coordXXX, coordYYY: $coordYYY, sheetTitle: $sheetTitle)
+                .interactiveDismissDisabled()
         } // 약속장소 지도 sheet
         .sheet(isPresented: $isShowPenalty) {
             HStack {


### PR DESCRIPTION
## 🚀관련 이슈
- <fix> #388 

## ✨작업 내용
- 카카오로컬API 검색을 통해 표시하는 카테고리 수정
  - category_group_name보다 더 넓은 범위인 categoryName의 마지막 카테고리를 보여주게 수정
  - 장소명이 14자를 초과할 경우, 14자 이후부터 '...'으로 표시하게 변경
  - 약속장소 설정시 올라오는 sheet를 슬라이드로 내려가지 않도록 수정
- 장소 검색 이후 리스트 좌측 상단 취소버튼 표시

