### PR TITLE
내주변 장소 검색 기능 구현

### DIFF
--- a/Zipadoo/Zipadoo.xcodeproj/project.pbxproj
+++ b/Zipadoo/Zipadoo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0431CE1D2B4290B200D2E04D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0431CE1C2B4290B200D2E04D /* GoogleService-Info.plist */; };
 		043B06D42B17068900722DD2 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		047127952AD7BE4F00767E9C /* OneMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047127942AD7BE4F00767E9C /* OneMapView.swift */; };
 		047127972AD7C7A800767E9C /* OneAddLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047127962AD7C7A800767E9C /* OneAddLocation.swift */; };
@@ -27,7 +28,6 @@
 		1BF69BD82ABD16B800DE635D /* TossPayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BF69BD72ABD16B800DE635D /* TossPayView.swift */; };
 		1BF69BDB2ABD16C500DE635D /* TossPayments in Frameworks */ = {isa = PBXBuildFile; productRef = 1BF69BDA2ABD16C500DE635D /* TossPayments */; };
 		3F13F0B92ABC277C00BCFC00 /* FriendsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F13F0B82ABC277C00BCFC00 /* FriendsView.swift */; };
-		3F4C16AC2B39712E00F2D1DB /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3F4C16AB2B39712E00F2D1DB /* GoogleService-Info.plist */; };
 		3F5B9A202AD6BACE00CDD52D /* FriendProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5B9A1F2AD6BACE00CDD52D /* FriendProfileView.swift */; };
 		3F6C02912B0ED3FA00FCA74B /* SlidingTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C02902B0ED3FA00FCA74B /* SlidingTabView.swift */; };
 		3F6D17942B039919007C8998 /* ProgressSubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6D17932B039919007C8998 /* ProgressSubView.swift */; };
@@ -165,6 +165,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0431CE1C2B4290B200D2E04D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		047127942AD7BE4F00767E9C /* OneMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneMapView.swift; sourceTree = "<group>"; };
 		047127962AD7C7A800767E9C /* OneAddLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneAddLocation.swift; sourceTree = "<group>"; };
 		04DA5A792B04C5ED00C1EEBA /* ParticipantInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantInfoView.swift; sourceTree = "<group>"; };
@@ -182,7 +183,6 @@
 		1B6C11C22AD6825D00770D43 /* PromiseEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromiseEditView.swift; sourceTree = "<group>"; };
 		1BF69BD72ABD16B800DE635D /* TossPayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TossPayView.swift; sourceTree = "<group>"; };
 		3F13F0B82ABC277C00BCFC00 /* FriendsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsView.swift; sourceTree = "<group>"; };
-		3F4C16AB2B39712E00F2D1DB /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Desktop/Documentation/지파두/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3F5B9A1F2AD6BACE00CDD52D /* FriendProfileView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FriendProfileView.swift; sourceTree = "<group>"; };
 		3F6C02902B0ED3FA00FCA74B /* SlidingTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlidingTabView.swift; sourceTree = "<group>"; };
 		3F6D17932B039919007C8998 /* ProgressSubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressSubView.swift; sourceTree = "<group>"; };
@@ -628,7 +628,7 @@
 				C069D2B92AC141AC00A62E04 /* Info.plist */,
 				C069D2B82AC1167800A62E04 /* Zipadoo.entitlements */,
 				FAD5FE3C2ABBD3E700E05E6E /* ZipadooApp.swift */,
-				3F4C16AB2B39712E00F2D1DB /* GoogleService-Info.plist */,
+				0431CE1C2B4290B200D2E04D /* GoogleService-Info.plist */,
 				FAD5FE4D2ABBD43600E05E6E /* Extention */,
 				FAD5FE4F2ABBD47A00E05E6E /* Modifier */,
 				FA103F1C2AE2163900BE56CA /* Enum */,
@@ -783,11 +783,12 @@
 			};
 			buildConfigurationList = FAD5FE342ABBD3E700E05E6E /* Build configuration list for PBXProject "Zipadoo" */;
 			compatibilityVersion = "Xcode 14.0";
-			developmentRegion = en;
+			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 				Base,
+				ko,
 			);
 			mainGroup = FAD5FE302ABBD3E700E05E6E;
 			packageReferences = (
@@ -822,6 +823,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8B56E9922ABBD9C3006CE010 /* .swiftlint.yml in Resources */,
+				0431CE1D2B4290B200D2E04D /* GoogleService-Info.plist in Resources */,
 				8B56E9922ABBD9C3006CE010 /* .swiftlint.yml in Resources */,
 				8B56E9922ABBD9C3006CE010 /* .swiftlint.yml in Resources */,
 				FAD5FE442ABBD3E800E05E6E /* Preview Assets.xcassets in Resources */,

--- a/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/NewMapViews/AddPlaceButtonCell.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/NewMapViews/AddPlaceButtonCell.swift
@@ -12,11 +12,12 @@ import MapKit
 /// 장소 검색 이후 장소 등록을 위한 뷰모델
 struct AddPlaceButtonCell: View {
     @Environment(\.dismiss) private var dismiss /// 이전 뷰(AddPromiseView)로 돌아가는 함수
-    @ObservedObject var promiseViewModel: PromiseViewModel
+//    @ObservedObject var promiseViewModel: PromiseViewModel
     var addLocationStore: AddLocationStore = AddLocationStore()
     @Binding var isClickedPlace: Bool
     @Binding var placeOfText: String
     @Binding var addLocationButton: Bool
+    @Binding var isClickedDestination: String
     @Binding var destination: String
     @Binding var address: String
     @Binding var coordXXX: Double
@@ -37,7 +38,7 @@ struct AddPlaceButtonCell: View {
                                     // X 버튼을 클릭 시 해당 장소에 대한 데이터 값들이 초기화됨
                                     Button {
                                         isClickedPlace = false
-                                        destination = ""
+                                        isClickedDestination = ""
                                         address = ""
                                         placeOfText = ""
                                     } label: {
@@ -54,17 +55,17 @@ struct AddPlaceButtonCell: View {
                             VStack {
                                 Spacer()
                                 
-                                Text(destination)
+                                Text(isClickedDestination)
                                     .font(.title3)
                                     .foregroundStyle(.primary)
-                                    .padding(.top)
                                     .padding(.horizontal)
+                                    .padding(.top, 5)
                                 
                                 Spacer()
                                 
                                 // 클릭한 장소에 대해 선택하기 버튼을 클릭하면 해당 장소에 대한 값들을 promiseLocation에 입력시킴
                                 Button {
-                                    destination = destination
+                                    destination = isClickedDestination
                                     address = address
                                     coordXXX = coordXXX
                                     coordYYY = coordYYY

--- a/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/NewMapViews/SearchbarCell.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/NewMapViews/SearchbarCell.swift
@@ -12,37 +12,43 @@ import CoreLocation
 // MARK: - 장소검색 검색창 뷰모델
 /// 장소검색을 위한 검색창 뷰모델
 struct SearchBarCell: View {
-    @ObservedObject var promiseViewModel: PromiseViewModel
+//    @ObservedObject var promiseViewModel: PromiseViewModel
     @ObservedObject var searchOfKakaoLocal: SearchOfKakaoLocal = SearchOfKakaoLocal.sharedInstance
     /// 검색 키워드
     @State private var searchText: String = ""
     /// 검색버튼에 의한 리스트 도출 값
     @State var searching: Bool = false
-    /// 거리로 부터 20km내의 검색결과 제공
-    @State private var radius: Int = 20000
+    /// 거리로 부터 5km내의 검색결과 제공
+    @State private var radius: Int = 5000
     /// 장소에 대한 URL 값 (카카오맵 기반)
     @State private var placeURL: String?
     /// 검색 결과 리스트의 i 버튼 클릭 값
     @State private var clickedPlaceInfo: Bool = false
     @State private var textFieldText: String = "키워드를 입력하세요."
-//    @State private var myLocation: Bool = false
-    
+    /// 내주변과 관련된 텍스트 표시 애니메이션 Bool값
+    @State private var isTextVisible = false
     var locationManager: LocationManager = LocationManager()
+    
+    @Binding var isClickedDestination: String
     @Binding var selectedPlace: Bool
     @Binding var isClickedPlace: Bool
-    @Binding var destination: String
+    @Binding var myLocation: Bool
     @Binding var address: String
     @Binding var coordXXX: Double
     @Binding var coordYYY: Double
     @Binding var selectedPlacePosition: CLLocationCoordinate2D?
-//    @Binding var promiseLocation: PromiseLocation
     
     var body: some View {
         VStack {
             HStack {
                 // 장소(키워드) 입력창
                 TextField(textFieldText, text: $searchText)
-                    .textFieldStyle(.roundedBorder)
+                    .padding(.horizontal, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(Color.primaryInvert2)
+                            .frame(height: 33)
+                    )
                     .autocapitalization(.none)
                     .autocorrectionDisabled()
                 // Search 버튼
@@ -52,7 +58,7 @@ struct SearchBarCell: View {
                         isClickedPlace = false
                         selectedPlace = false
                         // 카카오로컬 API를 활용하여 카카오로컬에 담긴 JSON파일과 통신하여 데이터를 불러옴
-                        searchOfKakaoLocal.searchKLPlace(keyword: searchText, currentPoiX: String(locationManager.location?.coordinate.latitude ?? 0.0), currentPoiY: String(locationManager.location?.coordinate.longitude ?? 0.0), radius: radius, sort: /*myLocation ? "distance" : */"accuracy")
+                        searchOfKakaoLocal.searchKLPlace(keyword: searchText, currentPoiX: myLocation ? String(locationManager.location?.coordinate.longitude ?? 0.0) : "0.0", currentPoiY: myLocation ? String(locationManager.location?.coordinate.latitude ?? 0.0) : "0.0", radius: myLocation ? radius : 0, sort: myLocation ? "distance" : "accuracy")
                         print("현재 사용자 위도(장소검색): \(locationManager.location?.coordinate.latitude ?? 0.0)")
                         print("현재 사용자 경도(장소검색): \(locationManager.location?.coordinate.longitude ?? 0.0)")
                     } else { // searchText가 빈 값일 경우 해당 텍스트를 보여줌
@@ -68,123 +74,178 @@ struct SearchBarCell: View {
                 }
                 .tint(.white)
             }
-            .padding()
+            .padding(5)
+            .padding(.top, 10)
             
             /// 검색버튼을 눌렀을 경우, searching값이 true가 되어 검색결과에 대한 리스트값 도출
             if searching == true {
                 HStack {
                     Button {
-//                        myLocation = false
                         searching = false
                         searchText = ""
+                        myLocation = false
                     } label: {
                         Text("취소")
                     }
                     .tint(.red)
-                    .padding(.leading, 5)
+                    .padding(.leading, 7)
                     
                     Spacer()
-                    
-//                    Text("내 주변")
-//                    Button {
-//                        myLocation.toggle()
-//                        searchOfKakaoLocal.searchKLPlace(keyword: searchText, currentPoiX: String(locationManager.location?.coordinate.latitude ?? 0.0), currentPoiY: String(locationManager.location?.coordinate.longitude ?? 0.0), radius: radius, sort: myLocation ? "distance" : "accuracy")
-//                    } label: {
-//                        Image(systemName: myLocation ? "checkmark.square.fill" : "checkmark.square")
-//                            .resizable()
-//                            .scaledToFit()
-//                            .frame(width: 15, height: 15)
-//                    }
-//                    .tint(.mocha)
-//                    .padding(.trailing, 5)
-                }
-                .padding(.top, -10)
-                
-                List(searchOfKakaoLocal.searchKakaoLocalDatas, id: \.place_name) { result in
                     VStack {
-                        Button {
-                            /// 클릭한 장소에 대한 위도경도 값을 변환하여 검색기능 맵뷰에 사용되는 promiseLocation 및 selectedPlacePosition 에 반영시킴
-                            if let xValue = Double(result.y), let yValue = Double(result.x) {
-                                coordXXX = xValue
-                                coordYYY = yValue
-                                selectedPlacePosition = CLLocationCoordinate2D(latitude: coordXXX, longitude: coordYYY)
-                            } else {
-                                print("변환 실패")
-                            }
-                            
-                            /// 장소 이름 설정
-                            destination = result.place_name
-                            /// 주소명 설정
-                            /// 장소에 대한 주소가 없을 시, 장소이름으로 장소에 대한 주소값 대체
-                            if result.road_address_name == "" {
-                                address = destination
-                            } else {
-                                address = result.road_address_name
-                            }
-                            
-                            print("장소 이름: \(destination)")
-                            print("카테고리: \(result.category_name)")
-                            print("주소: \(address)")
-                            print("장소 위도: \(selectedPlacePosition?.latitude ?? 0.0)")
-                            print("장소 경도: \(selectedPlacePosition?.longitude ?? 0.0)")
-                            print("거리: \(result.distance)")
-                            
-                            isClickedPlace = true
-                            searchText = ""
-                            textFieldText = "키워드를 입력하세요."
-                            selectedPlace = false
-                            searching = false
-//                            myLocation = false
-                            hideKeyboard()
-                        } label: {
-                            VStack(alignment: .leading) {
-                                HStack {
-                                    VStack(alignment: .leading) {
-                                        HStack {
-                                            Text(result.place_name.count > 14 || (result.place_name.count + category(categoryName: result.category_name).count > 23) || (result.place_name.count > 14 && category(categoryName: result.category_name).count > 10) ? result.place_name.prefix(13) + "..." : result.place_name)
-                                                .font(.headline)
-                                            
-                                            Text(category(categoryName: result.category_name))
-                                                .font(.caption).bold()
-                                                .foregroundColor(.blue)
-                                                .padding(.bottom, -3)
-                                                .padding(.leading, -7)
-                                            
-                                            Spacer()
+                        if myLocation {
+                            if isTextVisible {
+                                Text("내 주변 5km 내 가까운 장소를 검색합니다.")
+                                    .foregroundStyle(.gray)
+                                    .font(.system(size: 11))
+                                    .opacity(isTextVisible ? 1.0 : 0.0)
+                                    .padding(.leading, 30)
+                                    .onAppear {
+                                        // 뷰가 나타날 때 타이머 시작
+                                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                            // 3초 후에 텍스트가 사라지도록 상태 업데이트
+                                            withAnimation {
+                                                isTextVisible = false
+                                            }
                                         }
-                                        .foregroundColor(.primary)
-                                        
-                                        Text(result.road_address_name.isEmpty ? result.address_name : result.road_address_name)
-                                            .font(.subheadline)
-                                        
                                     }
-                                    //                                        .padding(.bottom, 5)
-                                    
-                                    /// ( i ) 버튼을 누르면 검색을 통해 얻은 url값으로 더 자세한 정보가 담긴 카카오맵 웹뷰 시트가 띄어짐
-                                    Button {
-                                        placeURL = result.place_url
-                                        clickedPlaceInfo.toggle()
-                                    } label: {
-                                        Image(systemName: "info.circle.fill")
-                                            .resizable()
-                                            .scaledToFit()
-                                            .frame(width: 30)
-                                    }
-                                    .tint(.mocha)
-                                    .padding(.trailing, -7)
-                                    .fullScreenCover(item: $placeURL) { url in
-                                        PlaceInfoWebView(urlString: url)
-                                    }
-                                }
                             }
                         }
                     }
+                    Spacer()
+                    
+                    Text("내 주변")
+                        .padding(.trailing, -5)
+                    
+                    Button {
+                        withAnimation(nil) {
+                            myLocation.toggle()
+                        }
+                        isTextVisible = true
+                        searchOfKakaoLocal.searchKLPlace(keyword: searchText, currentPoiX: myLocation ? String(locationManager.location?.coordinate.longitude ?? 0.0) : "0.0", currentPoiY: myLocation ? String(locationManager.location?.coordinate.latitude ?? 0.0) : "0.0", radius: myLocation ? radius : 0, sort: myLocation ? "distance" : "accuracy")
+                    } label: {
+                        Image(systemName: myLocation ? "checkmark.square.fill" : "square")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 18, height: 18)
+                    }
+                    .tint(.mocha)
+                    .padding(.trailing, 7)
                 }
-                .listStyle(.plain)
-                .scrollIndicators(.hidden)
-                .padding(.bottom)
-                .cornerRadius(5, corners: .bottomLeft)
-                .cornerRadius(5, corners: .bottomRight)
+                .padding(.vertical, 3)
+                
+                if searchOfKakaoLocal.searchKakaoLocalDatas.isEmpty {
+                    ContentUnavailableView(myLocation ? "내 주변 가까운 장소가 없습니다." : "검색 결과가 없습니다.", systemImage: "magnifyingglass", description: Text("다른 키워드로 검색해보세요."))
+                        .padding(.bottom, 50)
+                    
+                    Spacer()
+                    
+                } else {
+                    ScrollView {
+                        VStack(spacing: 0) {
+                                Divider()
+                                    .frame(width: .infinity)
+                                    .padding(.top, -1)
+                            
+                            ForEach(searchOfKakaoLocal.searchKakaoLocalDatas, id: \.place_name) { result in
+                                VStack {
+                                    Button {
+                                        /// 클릭한 장소에 대한 위도경도 값을 변환하여 검색기능 맵뷰에 사용되는 promiseLocation 및 selectedPlacePosition 에 반영시킴
+                                        if let xValue = Double(result.y), let yValue = Double(result.x) {
+                                            coordXXX = xValue
+                                            coordYYY = yValue
+                                            selectedPlacePosition = CLLocationCoordinate2D(latitude: coordXXX, longitude: coordYYY)
+                                        } else {
+                                            print("변환 실패")
+                                        }
+                                        
+                                        /// 장소 이름 설정
+                                        isClickedDestination = result.place_name
+                                        /// 주소명 설정
+                                        /// 장소에 대한 주소가 없을 시, 장소이름으로 장소에 대한 주소값 대체
+                                        if result.road_address_name == "" {
+                                            address = result.address_name
+                                        } else {
+                                            address = result.road_address_name
+                                        }
+                                        
+                                        print("장소 이름: \(isClickedDestination)")
+                                        print("카테고리: \(result.category_name)")
+                                        print("주소: \(address)")
+                                        print("장소 위도: \(selectedPlacePosition?.latitude ?? 0.0)")
+                                        print("장소 경도: \(selectedPlacePosition?.longitude ?? 0.0)")
+                                        print("거리: \(result.distance)")
+                                        isClickedPlace = true
+                                        searchText = ""
+                                        textFieldText = "키워드를 입력하세요."
+                                        selectedPlace = false
+                                        searching = false
+                                        myLocation = false
+                                        hideKeyboard()
+                                        
+                                    } label: {
+                                        VStack(alignment: .leading) {
+                                            HStack {
+                                                VStack(alignment: .leading) {
+                                                    HStack {
+                                                        Text(result.place_name.count >= 13 || (result.place_name.count + category(categoryName: result.category_name).count > 21) || (result.place_name.count >= 14 && category(categoryName: result.category_name).count >= 8) ? result.place_name.prefix(12) + "..." : result.place_name)
+                                                            .font(.system(size: 16)).bold()
+                                                        
+                                                        Text(category(categoryName: result.category_name))
+                                                            .font(.system(size: 9)).bold()
+                                                            .foregroundColor(.blue)
+                                                            .padding(.bottom, -5)
+                                                            .padding(.leading, -7)
+                                                        
+                                                        Spacer()
+                                                    }
+                                                    .foregroundColor(.primary)
+                                                    
+                                                    Text(result.road_address_name.isEmpty ? result.address_name : result.road_address_name)
+                                                        .font(.system(size: 13))
+                                                        .foregroundStyle(.gray)
+                                                }
+                                                
+                                                if myLocation {
+                                                    Text("\(formatDistance(Double(result.distance) ?? 0.0))")
+                                                        .font(.system(size: 13))
+                                                        .foregroundStyle(.gray)
+                                                }
+                                                /// ( i ) 버튼을 누르면 검색을 통해 얻은 url값으로 더 자세한 정보가 담긴 카카오맵 웹뷰 시트가 띄어짐
+                                                Button {
+                                                    placeURL = result.place_url
+                                                    clickedPlaceInfo.toggle()
+                                                } label: {
+                                                    Image(systemName: "info.circle.fill")
+                                                        .resizable()
+                                                        .scaledToFit()
+                                                        .frame(width: 35)
+                                                }
+                                                .tint(.mocha)
+                                                .fullScreenCover(item: $placeURL) { url in
+                                                    PlaceInfoWebView(urlString: url)
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                .padding(.horizontal, 15)
+                                .padding(.vertical)
+                                
+                                Divider()
+                                    .frame(width: .infinity)
+                                    .padding(.bottom, -1)
+                            }
+                        }
+                    }
+                    .scrollIndicators(.hidden)
+                    .scrollBounceBehavior(.basedOnSize)
+                    .background {
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(Color.primaryInvert)
+                    }
+                    .padding(.horizontal, 5)
+                    .padding(.bottom)
+                }
             }
         }
     }
@@ -198,10 +259,19 @@ struct SearchBarCell: View {
             return categoryName
         }
     }
+    
+    private func formatDistance(_ distance: CLLocationDistance) -> String {
+        if distance < 1000 {
+            return String(format: "%.0f m", distance)
+        } else {
+            let distanceInKilometers = distance / 1000.0
+            return String(format: "%.2f km", distanceInKilometers)
+        }
+    }
 }
 
 #Preview {
-    SearchBarCell(promiseViewModel: PromiseViewModel(), selectedPlace: .constant(false), isClickedPlace: .constant(false), destination: .constant("장소명"), address: .constant("주소"), coordXXX: .constant(0.0), coordYYY: .constant(0.0),
+    SearchBarCell(/*promiseViewModel: PromiseViewModel(),*/ isClickedDestination: .constant(""), selectedPlace: .constant(false), isClickedPlace: .constant(false), myLocation: .constant(false), address: .constant("주소"), coordXXX: .constant(0.0), coordYYY: .constant(0.0),
         selectedPlacePosition: .constant(CLLocationCoordinate2D(latitude: 37.39570088983171, longitude: 127.1104335101161)))
 }
 

--- a/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/OneAddLocation.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/OneAddLocation.swift
@@ -10,7 +10,6 @@ import SwiftUI
 /// 직접 장소 설정 시 띄워지는 장소 선택뷰
 struct OneAddLocation: View {
     @Environment(\.dismiss) private var dismiss
-    @ObservedObject var promiseViewModel: PromiseViewModel
     
     @Binding var destination: String
     @Binding var address: String
@@ -87,5 +86,5 @@ struct OneAddLocation: View {
 }
 
 #Preview {
-    OneAddLocation(promiseViewModel: PromiseViewModel(), destination: .constant(""), address: .constant(""), coordXXX: .constant(0.0), coordYYY: .constant(0.0), placeOfText: .constant("placeOfText"), selectedPlace: .constant(false), isClickedPlace: .constant(false))
+    OneAddLocation(destination: .constant(""), address: .constant(""), coordXXX: .constant(0.0), coordYYY: .constant(0.0), placeOfText: .constant("placeOfText"), selectedPlace: .constant(false), isClickedPlace: .constant(false))
 }

--- a/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/OneMapView.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/OneMapView.swift
@@ -13,7 +13,7 @@ struct OneMapView: View {
     
     @Environment(\.dismiss) private var dismiss
     
-    @ObservedObject var promiseViewModel: PromiseViewModel
+//    @ObservedObject var promiseViewModel: PromiseViewModel
     /// 연관된 값들을 한 공간에 이름을 지어 모아둔 공간, mapControls를 사용하기 위해 호출함
     @Namespace var mapScope
     /// 카카오 로컬 장소검색을 위한 클래스
@@ -30,7 +30,10 @@ struct OneMapView: View {
     @State private var pinLocation: CLLocationCoordinate2D? = nil
     /// 직접 클릭한 장소명에 대해 사용자가 입력할 수 있는 값
     @State private var placeOfText: String = ""
-
+    /// 약속장소명 뷰모델
+    @State private var isClickedDestination: String = ""
+    /// 내주변 활성화 Bool값
+    @State private var myLocation: Bool = false
     /// 약속장소 장소명 값
     @Binding var destination: String
     /// 약속장소 주소 값
@@ -112,16 +115,35 @@ struct OneMapView: View {
                     })
                 }
                 if isClickedPlace == true { // 화면을 클릭해서 장소를 선택한 값이 true일 경우, 해당 옵션의 장소선택 결정뷰를 띄워줌
-                    AddPlaceButtonCell(promiseViewModel: promiseViewModel, isClickedPlace: $isClickedPlace, placeOfText: $placeOfText, addLocationButton: $addLocationButton, destination: $destination, address: $address, coordXXX: $coordXXX, coordYYY: $coordYYY)
+                    AddPlaceButtonCell(isClickedPlace: $isClickedPlace, placeOfText: $placeOfText, addLocationButton: $addLocationButton, isClickedDestination: $isClickedDestination, destination: $destination, address: $address, coordXXX: $coordXXX, coordYYY: $coordYYY)
 //                    AddPlaceButtonCell(isClickedPlace: $isClickedPlace, placeOfText: $placeOfText, addLocationButton: $addLocationButton, destination: $destination, address: $address, coordXXX: $coordXXX, coordYYY: $coordYYY, promiseLocation: $promiseLocation)
                 } else if selectedPlace == true {// 화면을 클릭해서 장소를 선택한 값이 true일 경우, 해당 옵션의 장소선택 결정뷰를 띄워줌
-                    OneAddLocation(promiseViewModel: promiseViewModel, destination: $destination, address: $address, coordXXX: $coordXXX, coordYYY: $coordYYY, placeOfText: $placeOfText, selectedPlace: $selectedPlace, isClickedPlace: $isClickedPlace)
+                    OneAddLocation(destination: $destination, address: $address, coordXXX: $coordXXX, coordYYY: $coordYYY, placeOfText: $placeOfText, selectedPlace: $selectedPlace, isClickedPlace: $isClickedPlace)
                 } else {
                     
                 }
             }
             .navigationTitle(sheetTitle)
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
+                        myLocation = false
+                        dismiss()
+                        if isClickedPlace == true && addLocationButton == false {
+                            if destination.isEmpty {
+                                destination = ""
+                                address = ""
+                                coordXXX = 0.0
+                                coordYYY = 0.0
+                            }
+                        }
+                    } label: {
+                        Text("닫기")
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
             // 기본적으로 키보드를 보여지지 않게 함
             .onTapGesture {
                 hideKeyboard()
@@ -130,7 +152,7 @@ struct OneMapView: View {
             .onMapCameraChange(frequency: .onEnd) {
                 // transform() 함수 호출을 제거하고 selectedPlacePosition을 직접 갱신
                 if isClickedPlace == true {
-                    placePosition = .camera(MapCamera(centerCoordinate: CLLocationCoordinate2D(latitude: selectedPlacePosition?.latitude ?? 37.5665, longitude: selectedPlacePosition?.longitude ?? 126.9780), distance: 2500))
+                    placePosition = .camera(MapCamera(centerCoordinate: CLLocationCoordinate2D(latitude: selectedPlacePosition?.latitude ?? 37.5665, longitude: selectedPlacePosition?.longitude ?? 126.9780), distance: 1200))
                 }
             }
             // 맵컨트롤 버튼들을 우츨 상단에 위치시킴
@@ -153,7 +175,7 @@ struct OneMapView: View {
             .safeAreaInset(edge: .bottom) {
                 HStack {
                     Spacer()
-                    SearchBarCell(promiseViewModel: promiseViewModel, selectedPlace: $selectedPlace, isClickedPlace: $isClickedPlace, destination: $destination, address: $address, coordXXX: $coordXXX, coordYYY: $coordYYY, selectedPlacePosition: $selectedPlacePosition)
+                    SearchBarCell(/*promiseViewModel: promiseViewModel,*/isClickedDestination: $isClickedDestination, selectedPlace: $selectedPlace, isClickedPlace: $isClickedPlace, myLocation: $myLocation, address: $address, coordXXX: $coordXXX, coordYYY: $coordYYY, selectedPlacePosition: $selectedPlacePosition)
                     Spacer()
                 }
                 .background(.ultraThinMaterial)

--- a/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/PreviewPlaceOnMap.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/PreviewPlaceOnMap.swift
@@ -12,7 +12,7 @@ import MapKit
 struct PreviewPlaceOnMap: View {
     /// 선택한 약속장소에 대한 카메라 포지션 값
     @State private var position: MapCameraPosition = MapCameraPosition.automatic
-    @ObservedObject var promiseViewModel: PromiseViewModel
+//    @ObservedObject var promiseViewModel: PromiseViewModel
     
     @Binding var destination: String
     @Binding var address: String

--- a/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/SearchInKakaoLocal.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPomisePlaceSubViews/SearchInKakaoLocal.swift
@@ -57,11 +57,15 @@ class SearchOfKakaoLocal: ObservableObject {
         
         func fetchData() {
             var lists: [KakaoLocalData] = []
-            var metaInfo = MetaInfo(total_count: 0, pageable_count: 0, is_end: false)
-            self.metaInfos = metaInfo
+//            let metaInfo = MetaInfo(total_count: 0, pageable_count: 0, is_end: false)
+            let distance = "https://dapi.kakao.com/v2/local/search/keyword.json?y=\(currentPoiY)&x=\(currentPoiX)&radius=\(String(radius))"
+            let accuracy = "https://dapi.kakao.com/v2/local/search/keyword.json?"
             
-            searchKakaoLocalDatas = lists //y=\(currentPoiX)&x=\(currentPoiX)&radius=\(radius)
-            AF.request("https://dapi.kakao.com/v2/local/search/keyword.json?", method: .get, parameters: parameters, headers: headers)
+//            self.metaInfos = metaInfo
+            
+            searchKakaoLocalDatas = lists
+            
+            AF.request(sort == "accuracy" ? accuracy : distance, method: .get, parameters: parameters, headers: headers)
                 .validate()
                 .responseJSON(completionHandler: { response in
                     switch response.result {

--- a/Zipadoo/Zipadoo/Views/Home/AddPromise/AddPromiseView.swift
+++ b/Zipadoo/Zipadoo/Views/Home/AddPromise/AddPromiseView.swift
@@ -160,7 +160,7 @@ struct AddPromiseView: View {
                                                 .foregroundStyle(Color.gray)
                                                 .padding(.top, 10)
                                             
-                                            PreviewPlaceOnMap(promiseViewModel: promiseViewModel, destination: $destination, address: $address, coordXXX: $coordXXX, coordYYY: $coordYYY)
+                                            PreviewPlaceOnMap(/*promiseViewModel: promiseViewModel, */destination: $destination, address: $address, coordXXX: $coordXXX, coordYYY: $coordYYY)
                                                 .presentationDetents([.height(700)])
                                                 .padding(.top, 15)
                                         }
@@ -316,7 +316,7 @@ struct AddPromiseView: View {
                 }
         } // 날짜/시간 선택 sheet
         .sheet(isPresented: $isShowAddPlaceMapSheet) {
-            OneMapView(promiseViewModel: promiseViewModel, destination: $destination, address: $address, coordXXX: $coordXXX, coordYYY: $coordYYY, sheetTitle: $sheetTitle)
+            OneMapView(/*promiseViewModel: promiseViewModel, */destination: $destination, address: $address, coordXXX: $coordXXX, coordYYY: $coordYYY, sheetTitle: $sheetTitle)
                 .interactiveDismissDisabled()
         } // 약속장소 지도 sheet
         .sheet(isPresented: $isShowPenalty) {

--- a/Zipadoo/Zipadoo/Views/Home/PromiseEditView.swift
+++ b/Zipadoo/Zipadoo/Views/Home/PromiseEditView.swift
@@ -143,7 +143,7 @@ struct PromiseEditView: View {
                 .presentationDetents([.fraction(0.7)])
         }
         .sheet(isPresented: $isShowingEditMapSheet) { // coordXXX, coordYYY
-            OneMapView(promiseViewModel: promiseViewModel, destination: $editedDestination, address: $editedAddress, coordXXX: $destinationLatitude, coordYYY: $destinationLongitude, sheetTitle: $sheetTitle)
+            OneMapView(/*promiseViewModel: promiseViewModel,*/destination: $editedDestination, address: $editedAddress, coordXXX: $destinationLatitude, coordYYY: $destinationLongitude, sheetTitle: $sheetTitle)
         }
         .sheet(isPresented: $isShowingPenalty, content: {
             HStack {


### PR DESCRIPTION
## 🚀관련 이슈
- <fix> #397 

## ✨작업 내용
- 내주변 장소 검색 기능 구현
  - myLocation 변수 생성
  - 약속장소 검색 후, 내주변 박스를 체크하면 myLocation이 토글, myLocation의 값에 따라 sort의 "accuracy"과 "distance"가 변경되며 배열이 정렬됨
  - "distance"는 5km 내의 가장 가까운 장소 리스트 표시
  - 리스트 디자인 수정
- 사용하지 않는 코드 및 promiseViewModel 주석처리
- 약속 장소 등록시 시트 상단에 취소 버튼 생성
  - 약속장소명 뷰모델인 isClickedDestination 변수 생성

## 📝참고 사항
- 검색어 변경 후 내주변 체크박스를 터치하면 변경된 검색어로 리스트 출력됨
