### PR TITLE
[FIX] 도착 메세지 뷰 다크모드 적용 #409

### DIFF
--- a/Zipadoo/Zipadoo.xcodeproj/project.pbxproj
+++ b/Zipadoo/Zipadoo.xcodeproj/project.pbxproj
@@ -55,7 +55,6 @@
 		8BEA8B9D2ADB0C640083D488 /* PromiseTrackingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEA8B9C2ADB0C640083D488 /* PromiseTrackingView.swift */; };
 		8BF831C92AC1FFDD00EC22A1 /* EditProfilView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF831C82AC1FFDD00EC22A1 /* EditProfilView.swift */; };
 		9A10ADFB2AD83D0900AF37A3 /* SlidingTabView in Frameworks */ = {isa = PBXBuildFile; productRef = 9A10ADFA2AD83D0900AF37A3 /* SlidingTabView */; };
-		9A2A42EF2B4EBE370080B671 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9A2A42EE2B4EBE370080B671 /* GoogleService-Info.plist */; };
 		9B8FE8272ACE377B00C1EEFC /* MyLocationAndInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8FE8262ACE377B00C1EEFC /* MyLocationAndInfoView.swift */; };
 		C02790B82ACD297100BBDCCA /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C02790B72ACD297100BBDCCA /* WidgetKit.framework */; };
 		C02790BA2ACD297100BBDCCA /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C02790B92ACD297100BBDCCA /* SwiftUI.framework */; };
@@ -80,6 +79,7 @@
 		C076BDA52AD934C1005AE81D /* ArrivalMsgModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C076BDA42AD934C1005AE81D /* ArrivalMsgModel.swift */; };
 		C076BDA82AD938D6005AE81D /* AlertStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C076BDA72AD938D6005AE81D /* AlertStore.swift */; };
 		C08716882AE25C99005914C5 /* WidgetStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08716872AE25C99005914C5 /* WidgetStore.swift */; };
+		FA009A3E2B6A0F6B006C2B79 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FA009A3D2B6A0F6B006C2B79 /* GoogleService-Info.plist */; };
 		FA103F1E2AE2164F00BE56CA /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA103F1D2AE2164F00BE56CA /* Enum.swift */; };
 		FA24740B2ACD4BDB00D4C821 /* FriendsLocationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2473E52ACD4BDB00D4C821 /* FriendsLocationListView.swift */; };
 		FA24740D2ACD4BDB00D4C821 /* SearchInKakaoLocal.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2473E82ACD4BDB00D4C821 /* SearchInKakaoLocal.swift */; };
@@ -213,7 +213,6 @@
 		8BDF9CCD2ABD1F7D00255857 /* FriendsRegistrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsRegistrationView.swift; sourceTree = "<group>"; };
 		8BEA8B9C2ADB0C640083D488 /* PromiseTrackingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromiseTrackingView.swift; sourceTree = "<group>"; };
 		8BF831C82AC1FFDD00EC22A1 /* EditProfilView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditProfilView.swift; sourceTree = "<group>"; };
-		9A2A42EE2B4EBE370080B671 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Desktop/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		9AB7E6452B2882CA0054D4B0 /* ZipadooWidgetExtensionDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ZipadooWidgetExtensionDebug.entitlements; sourceTree = "<group>"; };
 		9AB7E6462B2885960054D4B0 /* ZipadooDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ZipadooDebug.entitlements; sourceTree = "<group>"; };
 		9B8FE8262ACE377B00C1EEFC /* MyLocationAndInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyLocationAndInfoView.swift; sourceTree = "<group>"; };
@@ -237,6 +236,7 @@
 		C076BDA42AD934C1005AE81D /* ArrivalMsgModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrivalMsgModel.swift; sourceTree = "<group>"; };
 		C076BDA72AD938D6005AE81D /* AlertStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertStore.swift; sourceTree = "<group>"; };
 		C08716872AE25C99005914C5 /* WidgetStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetStore.swift; sourceTree = "<group>"; };
+		FA009A3D2B6A0F6B006C2B79 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		FA103F1D2AE2164F00BE56CA /* Enum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enum.swift; sourceTree = "<group>"; };
 		FA2473E52ACD4BDB00D4C821 /* FriendsLocationListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FriendsLocationListView.swift; sourceTree = "<group>"; };
 		FA2473E82ACD4BDB00D4C821 /* SearchInKakaoLocal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchInKakaoLocal.swift; sourceTree = "<group>"; };
@@ -646,8 +646,8 @@
 			children = (
 				9AB7E6462B2885960054D4B0 /* ZipadooDebug.entitlements */,
 				C069D2B92AC141AC00A62E04 /* Info.plist */,
-				9A2A42EE2B4EBE370080B671 /* GoogleService-Info.plist */,
 				C069D2B82AC1167800A62E04 /* Zipadoo.entitlements */,
+				FA009A3D2B6A0F6B006C2B79 /* GoogleService-Info.plist */,
 				FAD5FE3C2ABBD3E700E05E6E /* ZipadooApp.swift */,
 				FAD5FE4D2ABBD43600E05E6E /* Extention */,
 				FAD5FE4F2ABBD47A00E05E6E /* Modifier */,
@@ -845,7 +845,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8B56E9922ABBD9C3006CE010 /* .swiftlint.yml in Resources */,
-				9A2A42EF2B4EBE370080B671 /* GoogleService-Info.plist in Resources */,
+				FA009A3E2B6A0F6B006C2B79 /* GoogleService-Info.plist in Resources */,
 				8B56E9922ABBD9C3006CE010 /* .swiftlint.yml in Resources */,
 				8B56E9922ABBD9C3006CE010 /* .swiftlint.yml in Resources */,
 				FAD5FE442ABBD3E800E05E6E /* Preview Assets.xcassets in Resources */,

--- a/Zipadoo/Zipadoo/Views/Alert/ArrivalMessagingView.swift
+++ b/Zipadoo/Zipadoo/Views/Alert/ArrivalMessagingView.swift
@@ -135,7 +135,7 @@ struct ArrivalMessagingView: View {
                     .stroke(.brown.opacity(0.5))
                     .background(
                         RoundedRectangle(cornerRadius: 30)
-                            .fill(.white)
+                            .fill(Color(UIColor.systemBackground))
                     )
                 
             )
@@ -196,7 +196,6 @@ struct ArrivalMessagingView: View {
         //                }
         //            }
         //        }
-        
     }
     
     // MARK: - 도착정보


### PR DESCRIPTION
## 🚀관련 이슈
- <fix> #409

## ✨작업 내용
- 다크 모드 사용시 도착 메세지 뷰에서 글자와 백그라운드 색상이 동일하여 안보이는 현상 해결

## 📸 스크린샷
<img  width="40%" src="https://github.com/APP-iOS2/final-zipadoo/assets/111691629/2d033242-99e6-467e-9b1e-b08904fc1053"/>
<img  width="40%" src="https://github.com/APP-iOS2/final-zipadoo/assets/111691629/7d35708b-2a9a-4666-a700-c48eeb25a173"/>

## 📝참고 사항
 - 환경변수 미사용